### PR TITLE
Fix icons position on Studio when a device is set.

### DIFF
--- a/StatusBarLayer.coffee
+++ b/StatusBarLayer.coffee
@@ -163,10 +163,8 @@ class StatusBarLayer extends Layer
 		appleSVGCSS = """
 			.svgFit {
 			  object-fit: contain;
-			  width: 100%;
-			  height: 100%;
-			  max-width: 100%;
-			  max-height: 100%;
+			  position: absolute;
+			  top: 0;
 			}
 			"""
 


### PR DESCRIPTION
## Problem
Icons look too small and misaligned when a device is set on Framer Studio.

[![Screen_Shot_2017-10-23_at_12.09.42.png](https://s1.postimg.org/7suyqciipr/Screen_Shot_2017-10-23_at_12.09.42.png)](https://postimg.org/image/9o7jiyuybf/) 

## Solution
Simplify CSS used on the appleSVGCSS.

[![Screen_Shot_2017-10-23_at_12.12.03.png](https://s1.postimg.org/9ea8i5lo33/Screen_Shot_2017-10-23_at_12.12.03.png)](https://postimg.org/image/182nrnkenf/)