### PR TITLE
Add option to use 24 hours format

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ myStatusBar = new StatusBarLayer
 	# Text
 	carrier: <string>
 	time: <string> # if not set, will use local time
+	hours24: <boolean> # 12-hours format is the default
 	percent: <number>
 	
 	# Show or hide status items

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ myStatusBar = new StatusBarLayer
 	# Text
 	carrier: <string>
 	time: <string> # if not set, will use local time
-	hours24: <boolean> # 12-hours format is the default
+	hours24: <boolean> # 12-hours format by default, ignored if time is set 
 	percent: <number>
 	
 	# Show or hide status items

--- a/StatusBarLayer.coffee
+++ b/StatusBarLayer.coffee
@@ -56,6 +56,7 @@ defaults =
 	onCall: false
 	vibrant: false
 	version: 11
+	hours24: false
 
 # iOS 11 unfilled signal bar is 25%
 # iOS 11 battery stroke is 35%
@@ -272,10 +273,10 @@ class StatusBarLayer extends Layer
 			minute = today.getMinutes()
 			second = today.getSeconds()
 			suffix = if hour >= 12 then ' PM' else ' AM'
-			hour = if hour > 12 then hour - 12 else hour
+			hour = if !@options.hours24 and hour > 12 then hour - 12 else hour
 			minute = if minute < 10 then "0" + minute else minute
 			if @options.time == ""
-				return hour + ':' + minute + suffix
+				return hour + ':' + minute + (if !@options.hours24 then suffix else '')
 			else
 				return @options.time
 


### PR DESCRIPTION
## Problem
Not able to use 24 hours format with the local time.

## Solution
Add a option <boolean> to use it.

[![Screen_Shot_2017-10-23_at_17.48.19.png](https://s1.postimg.org/4wu0h3mqpb/Screen_Shot_2017-10-23_at_17.48.19.png)](https://postimg.org/image/8r2s024omj/)